### PR TITLE
fix: all nodes showing same name "RH Skyreels V4 Image to Video Fast"

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -144,7 +144,7 @@ def _generate_i18n_files():
     panel_nodes_zh = {}
 
     for m in all_node_defs:
-        iname = m.get("internal_name", "")
+        iname = m.get("internal_name") or (f"RH_{m['class_name']}" if m.get("class_name") else "")
         name_cn = m.get("name_cn", "")
         name_en = m.get("name_en", "")
         display_cn = m.get("display_name", "")


### PR DESCRIPTION

<img width="616" height="350" alt="RH API BUG" src="https://github.com/user-attachments/assets/d5081be2-8195-4a93-aab3-f29dc1d51162" />

## Bug Fix: All nodes showing same name "RH Skyreels V4 Image to Video Fast"

### Problem
After installing this plugin, every newly added node in ComfyUI displays the name "RH Skyreels V4 Image to Video Fast" instead of its own name.

### Root Cause
In `_generate_i18n_files()` (`__init__.py` line 147):

```python
# Before (bug)
iname = m.get("internal_name", "")
```

All 299 entries in `models_registry.json` have `internal_name: null`. So every entry writes to the same `""` key, leaving only the last entry ("RH Skyreels V4 Image to Video Fast") in `panel_i18n.json`. The frontend JS then applies this name to all nodes.

### Fix
Use the same fallback logic already used in `create_all_nodes()` (node_factory.py line 967):

```python
# After (fixed)
iname = m.get("internal_name") or (f"RH_{m['class_name']}" if m.get("class_name") else "")
```

### Testing
- Disabled plugin → problem disappears 
- With fix applied: [`panel_i18n.json`](<img width="616" height="350" alt="RH API BUG" src="https://github.com/user-attachments/assets/ef3c4267-e0e4-4353-b000-c4fdb2e3018b" />) now correctly contains 299 unique node keys instead of just 1